### PR TITLE
Fixes mass-assignment errors for params and locale

### DIFF
--- a/app/models/sellect/translation.rb
+++ b/app/models/sellect/translation.rb
@@ -3,7 +3,8 @@ module Sellect
     self.table_name = 'sellect_translations'
     belongs_to :translatable, polymorphic: true
 
-    attr_accessible :translation, :translation_type, :translation_id
+    attr_accessible :translation, :translation_type, :translation_id, 
+                    :params, :locale
 
     serialize :params
   end


### PR DESCRIPTION
@jGRUBBS Adding this so that you can run migrations for translations like this:

```
product.translations.create(locale: :fr, params: { name: 'funky', presentation: 'Funky' })
```
