### PR TITLE
Specifies sellect/translate dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,15 @@ class Product
   translate_fields :name, :description          # identify translatable columns
 
 end
+```
 
+Example - Creating translations on translatable fields:
 
+```ruby
+product.translations.create(locale: :fr, params: { name: 'funky', presentation: 'Funky' })
+```
+
+```ruby
 ## Contributing
 
 1. Fork it ( https://github.com/[my-github-username]/sellect-translate/fork )
@@ -49,3 +56,4 @@ end
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create a new Pull Request
+```

--- a/lib/sellect/translate.rb
+++ b/lib/sellect/translate.rb
@@ -1,4 +1,5 @@
 require 'action_view/ext'
+require 'sellect/translate'
 require 'sellect/translate/version'
 require 'sellect/translate/railtie'
 require 'sellect/translate/getter'


### PR DESCRIPTION
This dependency needs to be added because Sidekiq keeps failing with the following error during batch imports that contain translatable fields:

```
Circular dependency detected while autoloading constant Sellect::Translation
```

This seems to be happening b/c it's trying to make an association with Sellect::Translation before Sellect::Translate is loaded.

```
# sellect/translate.rb
self.send(:has_many, :translations, { as: :translatable, class_name: 'Sellect::Translation'})
```
